### PR TITLE
Making help topics thread_local to avoid crashes.

### DIFF
--- a/help.cc
+++ b/help.cc
@@ -29,17 +29,19 @@
 #include "util.h"
 #include "botclient.h"
 
-
+#if __cplusplus >= 201103L // C++ v11 or newer
+thread_local std::list<HelpTopic> Help::topics;
+thread_local StrList Help::topicList;
+#else
 std::list<HelpTopic> Help::topics;
 StrList Help::topicList;
+#endif
 
 
 bool
 Help::haveTopic(const std::string & topic)
 {
   return (topics.end() != std::find(topics.begin(), topics.end(), topic));
-
-  return false;
 }
 
 

--- a/help.h
+++ b/help.h
@@ -32,8 +32,14 @@
 class Help
 {
 private:
+    
+#if __cplusplus >= 201103L // C++ v11 or newer    
+  static thread_local std::list<HelpTopic> topics;
+  static thread_local StrList topicList;
+#else
   static std::list<HelpTopic> topics;
-  static StrList topicList;
+  static StrList topicList;  
+#endif
 
   static bool haveTopic(const std::string &);
   static bool getIndex(class BotClient * client);


### PR DESCRIPTION
Making the lists thread_local does not lead to crashes during start up, this fixes #3 